### PR TITLE
Remove dependency for `fluentd 0.10.x`; more intuitive interpolated placeholders; rename fields populated by the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ The `docker_containers_path` is optional and defaults to `/var/lib/docker/contai
 
 The `container_id` parameter can either be a string with the id, or use the special interpolated substitution `${tag_parts[<some number>]}`. The tag parts are the dot-separated parts of the incoming tag, so that in the above example they would match the first star.
 
-A full example:
+The `tag` parameter either be:
+ - a string with the id
+ - use the special interpolated substitution `${tag_parts[<some number>]}`.
+   The tag parts are the dot-separated parts of the incoming tag,
+   so that in the above example they would match the first star.
+ - use the special interpolated substitution `${<field>}`,
+   where `field` is the field of the record,
+   including the new fields: `name`, `full_id` and `id` (see below).
+
+The output record will have the following additional fields:
+  - `name`: container name, e.g. `saint_stallman`
+  - `full_id`: full id of the container,
+    e.g. `ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79`
+  - `id`: abbreviated id of the container, e.g. `ffb4d30ab540`
+
+### A full example:
 
 ```
 <source>
@@ -48,11 +63,34 @@ A full example:
 <match docker.var.lib.docker.containers.*.*.log>
   type docker_format
   container_id ${tag_parts[5]}
-  tag docker.${name}
+  tag docker.${name}.${id}.${stream}
 </match>
 ```
 
-The output record will have two additional fields, `container_id` and `container_name`.
+So if an input event was
+
+```json
+{
+  "tag": "docker.var.lib.docker.containersffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79-json.log",
+  "time":"2015-01-29T22:01:28.583281971Z",
+  "stream":"stdout",
+  "log": "actual log line",
+}
+```
+
+it will become:
+
+```json
+{
+  "tag": "docker.saint_stallman.ffb4d30ab540.stdout",
+  "time":"2015-01-29T22:01:28.583281971Z",
+  "name": "saint_stallman",
+  "id": "ffb4d30ab540",
+  "full_id": "ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79",
+  "stream":"stdout",
+  "log": "actual log line",
+}
+```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ The output record will have the following additional fields:
     e.g. `ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79`
   - `id`: abbreviated id of the container, e.g. `ffb4d30ab540`
 
-### A full example:
+#### A full example
+
+Consider following config:
 
 ```
 <source>
@@ -54,7 +56,7 @@ The output record will have the following additional fields:
 </match>
 ```
 
-So if an input event was
+Then an input event
 
 ```json
 tag = docker.var.lib.docker.containers.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79-json.log
@@ -65,7 +67,7 @@ record = {
 }
 ```
 
-it will become:
+will become:
 
 ```json
 tag = docker.saint_stallman.ffb4d30ab540.stdout
@@ -87,7 +89,7 @@ record = {
 
     The parameter value is interpolated with the following placeholders:
       - `${tag}`: the input tag
-      - `${tag\_parts[N]}`: input tag splitted by '.' indexed with `N` such as
+      - `${tag_parts[N]}`: input tag splitted by '.' indexed with `N` such as
         `${tag_parts[0]}`, `${tag_parts[-1]}`. 
 
 - tag
@@ -96,9 +98,9 @@ record = {
 
     Tag parameter value is interpolated with the following placeholders:
       - `${tag}`: input tag
-      - `${tag\_parts[N]}`: input tag splitted by '.' indexed with `N` such as
+      - `${tag_parts[N]}`: input tag splitted by '.' indexed with `N` such as
         `${tag_parts[0]}`, `${tag_parts[-1]}`. 
-      - `${<field>}`: any record field including the newly added fields
+      - `${<field>}`: any record field including the new fields
 	(`id`, `full_id` and `name`)
 
 - docker_containers_path (optional)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The output record will have the following additional fields:
 
 <match docker.var.lib.docker.containers.*.*.log>
   type docker_format
-  container_id ${tag_parts[5]}
+  container_id ${tag_parts[-2]}
   tag docker.${name}.${id}.${stream}
 </match>
 ```

--- a/README.md
+++ b/README.md
@@ -29,19 +29,6 @@ Or install it yourself as:
 </match>
 ```
 
-The `docker_containers_path` is optional and defaults to `/var/lib/docker/containers`.
-
-The `container_id` parameter can either be a string with the id, or use the special interpolated substitution `${tag_parts[<some number>]}`. The tag parts are the dot-separated parts of the incoming tag, so that in the above example they would match the first star.
-
-The `tag` parameter either be:
- - a string with the id
- - use the special interpolated substitution `${tag_parts[<some number>]}`.
-   The tag parts are the dot-separated parts of the incoming tag,
-   so that in the above example they would match the first star.
- - use the special interpolated substitution `${<field>}`,
-   where `field` is the field of the record,
-   including the new fields: `name`, `full_id` and `id` (see below).
-
 The output record will have the following additional fields:
   - `name`: container name, e.g. `saint_stallman`
   - `full_id`: full id of the container,
@@ -62,7 +49,7 @@ The output record will have the following additional fields:
 
 <match docker.var.lib.docker.containers.*.*.log>
   type docker_format
-  container_id ${tag_parts[-2]}
+  container_id ${tag_parts[-3]}
   tag docker.${name}.${id}.${stream}
 </match>
 ```
@@ -70,9 +57,9 @@ The output record will have the following additional fields:
 So if an input event was
 
 ```json
-{
-  "tag": "docker.var.lib.docker.containersffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79-json.log",
-  "time":"2015-01-29T22:01:28.583281971Z",
+tag = docker.var.lib.docker.containers.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79.ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79-json.log
+time = 2015-01-29T22:01:28.583281971Z
+record = {
   "stream":"stdout",
   "log": "actual log line",
 }
@@ -81,9 +68,9 @@ So if an input event was
 it will become:
 
 ```json
-{
-  "tag": "docker.saint_stallman.ffb4d30ab540.stdout",
-  "time":"2015-01-29T22:01:28.583281971Z",
+tag = docker.saint_stallman.ffb4d30ab540.stdout
+time = 2015-01-29T22:01:28.583281971Z
+record = {
   "name": "saint_stallman",
   "id": "ffb4d30ab540",
   "full_id": "ffb4d30ab540b43e040a4cebbf968137cb0f17e21e61e90547113dfb83e3df79",
@@ -92,6 +79,32 @@ it will become:
 }
 ```
 
+## Option Parameters
+
+- container_id
+
+    The container id.
+
+    The parameter value is interpolated with the following placeholders:
+      - `${tag}`: the input tag
+      - `${tag\_parts[N]}`: input tag splitted by '.' indexed with `N` such as
+        `${tag_parts[0]}`, `${tag_parts[-1]}`. 
+
+- tag
+
+    The output tag.
+
+    Tag parameter value is interpolated with the following placeholders:
+      - `${tag}`: input tag
+      - `${tag\_parts[N]}`: input tag splitted by '.' indexed with `N` such as
+        `${tag_parts[0]}`, `${tag_parts[-1]}`. 
+      - `${<field>}`: any record field including the newly added fields
+	(`id`, `full_id` and `name`)
+
+- docker_containers_path (optional)
+
+    The path to docker containers directory;
+    defaults to `/var/lib/docker/containers`.
 
 ## Contributing
 

--- a/fluent-plugin-docker-format.gemspec
+++ b/fluent-plugin-docker-format.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "fluent-plugin-docker-format"
+  spec.name          = "fluent-plugin-docker-format-plntr"
   spec.version       = File.read("VERSION").strip
   spec.authors       = ["Alex Hornung"]
   spec.email         = ["alex@alexhornung.com"]

--- a/fluent-plugin-docker-format.gemspec
+++ b/fluent-plugin-docker-format.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "fluent-plugin-docker-format-plntr"
+  spec.name          = "fluent-plugin-docker-format"
   spec.version       = File.read("VERSION").strip
   spec.authors       = ["Alex Hornung"]
   spec.email         = ["alex@alexhornung.com"]
@@ -20,6 +20,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.4.2"
-
-#    spec.add_dependency "fluentd", "~> 0.10.17"
 end

--- a/fluent-plugin-docker-format.gemspec
+++ b/fluent-plugin-docker-format.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.4.2"
 
-  spec.add_dependency "fluentd", "~> 0.10.17"
+#    spec.add_dependency "fluentd", "~> 0.10.17"
 end

--- a/fluent-plugin-docker-format.gemspec
+++ b/fluent-plugin-docker-format.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "fluent-plugin-docker-format-plntr"
+  spec.name          = "fluent-plugin-docker-format"
   spec.version       = File.read("VERSION").strip
   spec.authors       = ["Alex Hornung"]
   spec.email         = ["alex@alexhornung.com"]

--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -51,10 +51,10 @@ module Fluent
     end
 
     def format_record(tag, record)
-      id = interpolate(tag, @container_id)
-      record['full_id'] = id
-      record['id'] = id[0..12]
-      record['name'] = get_name(id) || "<unknown>"
+      full_id = interpolate(tag, @container_id)
+      record['full_id'] = full_id
+      record['id'] = full_id[0..12]
+      record['name'] = get_name(full_id) || "<unknown>"
       record
     end
   end

--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -26,7 +26,8 @@ module Fluent
     def interpolate(tag, str)
       tag_parts = tag.split('.')
 
-      str.gsub(/\$\{tag_parts\[(-?\d+)\]\}/) { |m| tag_parts[$1.to_i] }
+      str.gsub(/\$\{tag\}/, tag)
+         .gsub(/\$\{tag_parts\[(-?\d+)\]\}/) { |m| tag_parts[$1.to_i] }
     end
 
     def interpolate_tag(tag, record)

--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -26,7 +26,7 @@ module Fluent
     def interpolate(tag, str)
       tag_parts = tag.split('.')
 
-      str.gsub(/\$\{tag_parts\[(\d+)\]\}/) { |m| tag_parts[$1.to_i] }
+      str.gsub(/\$\{tag_parts\[(-?\d+)\]\}/) { |m| tag_parts[$1.to_i] }
     end
 
     def interpolate_tag(tag, record)

--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -38,7 +38,8 @@ module Fluent
     def get_name_from_cfg(id)
       begin
         docker_cfg = JSON.parse(File.read("#{@docker_containers_path}/#{id}/config.json"))
-        container_name = docker_cfg['Name']
+	# Remove the leading '/'
+        container_name = docker_cfg['Name'][1..-1]
       rescue
         container_name = nil
       end


### PR DESCRIPTION
- remove dependency for `fluentd 0.10.x`
- `tag` parameter is interpolated with record fields, `tag_prefix[N]` and `tag`
- `container_id` parameter is interpolated with `tag`
- new fields are added to record:
  - `full_id` (instead of `container_id`)
  - `name` (instead of `container_name`), the leading `/` is removed
  - `id`: abbreviation of `full_id` (first 12 characters), same logic used by `docker` itself
- updated README
