### PR TITLE
Always chop of the / prefix

### DIFF
--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -31,7 +31,6 @@ module Fluent
     def interpolate_tag(tag)
       id = interpolate(tag, @container_id)
       name = get_name(id)
-      name = name[1..-1] if name
 
       @tag.gsub(/\$\{name\}/, name || id)
     end
@@ -39,7 +38,7 @@ module Fluent
     def get_name_from_cfg(id)
       begin
         docker_cfg = JSON.parse(File.read("#{@docker_containers_path}/#{id}/config.json"))
-        container_name = docker_cfg['Name']
+        container_name = docker_cfg['Name'][1..-1]
       rescue
         container_name = nil
       end


### PR DESCRIPTION
Instead of only stripping the slash, this does it all the time, so container_name will not include it.
