### PR TITLE
Fix determination of container name for docker 1.10

### DIFF
--- a/lib/fluent/plugin/out_docker_format.rb
+++ b/lib/fluent/plugin/out_docker_format.rb
@@ -38,7 +38,11 @@ module Fluent
 
     def get_name_from_cfg(id)
       begin
-        docker_cfg = JSON.parse(File.read("#{@docker_containers_path}/#{id}/config.json"))
+        config_path = "#{@docker_containers_path}/#{id}/config.json"
+        if not File.exists?(config_path)
+          config_path = "#{@docker_containers_path}/#{id}/config.v2.json"
+        end
+        docker_cfg = JSON.parse(File.read(config_path))
         container_name = docker_cfg['Name']
       rescue
         container_name = nil


### PR DESCRIPTION
- as of docker 1.10 the name of the config file is `config.v2.json`
- if `config.json` doesn't exist try `config.v2.json`

Fixes #5 
